### PR TITLE
feat: make progress bar title bold and bump version to v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -138,7 +138,7 @@ impl ProgressBar {
             queue!(
                 w,
                 MoveTo(0, row),
-                PrintStyledContent(title.to_string().with(Color::Reset))
+                PrintStyledContent(title.to_string().with(Color::Reset).bold())
             )?;
             row += 1;
             let top_border = "━".repeat(bar_width).to_string();


### PR DESCRIPTION
## Changes

- Make progress bar title bold for improved visibility
- Bump version to v0.5.1

## Technical Details

Added `.bold()` to the title display in `src/progress_bar.rs` to make the progress bar title appear in bold text. This improves readability and makes the title more prominent for users.

## Testing

All existing tests pass with these changes.