### PR TITLE
Fix terminal resize issue and expand progress bar to full width (v0.6.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"


### PR DESCRIPTION
## Summary

This PR fixes the terminal resize issue reported in Issue #77 and improves the progress bar to use the full terminal width.

### 🐛 Bug Fixes
- Fixed progress bar not resizing when terminal width changes
- Fixed progress bar width being limited instead of using full terminal width

### ✨ Improvements
- Removed fixed `bar_width` field from `RenderContext` structure
- All themes (Default, Retro, Cyberpunk) now dynamically get terminal width
- Implemented real-time adjustment when terminal is resized

### 🎯 Changed Files
- `src/theme.rs`: Modified progress bar width calculation to be dynamic
- `Cargo.toml`: Updated version to 0.6.1

### 🧪 Tested
- ✅ Default theme with full width display
- ✅ Retro theme with full width display  
- ✅ Cyberpunk theme with full width display
- ✅ Dynamic adjustment when terminal is resized

Closes #77