### PR TITLE
Fix remaining time calculation bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -12,6 +12,7 @@ pub struct Progress {
 impl Progress {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
     pub fn new(timespan: Timespan, current_time: NaiveDateTime) -> Self {
         let elapsed = if current_time < timespan.from {
             Duration::zero()
@@ -21,20 +22,18 @@ impl Progress {
             (current_time - timespan.from).max(Duration::zero())
         };
 
-        let ratio = if timespan.duration.num_seconds() <= 0 {
-            1.0
-        } else if current_time <= timespan.from {
-            0.0
-        } else if current_time >= timespan.to {
-            1.0
-        } else {
-            elapsed.num_milliseconds() as f64 / timespan.duration.num_milliseconds() as f64
-        };
-
         let remaining = if current_time > timespan.to {
             Duration::zero()
+        } else if current_time < timespan.from {
+            timespan.duration
         } else {
             (timespan.to - current_time).max(Duration::zero())
+        };
+
+        let ratio = {
+            let ratio = (elapsed.num_seconds() as f64 / timespan.duration.num_seconds() as f64)
+                .clamp(0.0, 1.0);
+            f64::from((ratio * 100.0) as i32) / 100.0
         };
 
         Self {
@@ -59,5 +58,75 @@ impl Progress {
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.timespan.has_expired(self.current_time)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_new() {
+        let fmt = "%Y-%m-%d %H:%M:%S";
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00:00", fmt).unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59:59", fmt).unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+
+        // current_time before from
+        let progress = Progress::new(timespan, from - Duration::hours(1));
+        assert_eq!(progress.ratio, 0.0);
+        assert_eq!(progress.elapsed, Duration::zero());
+        assert_eq!(progress.remaining, timespan.duration);
+
+        // current_time at from
+        let progress = Progress::new(timespan, from);
+        assert_eq!(progress.ratio, 0.0);
+        assert_eq!(progress.elapsed, Duration::zero());
+        assert_eq!(progress.remaining, timespan.duration);
+
+        // current_time between from and to
+        let progress = Progress::new(
+            timespan,
+            from + Duration::minutes(4) + Duration::seconds(48),
+        );
+        assert_eq!(progress.ratio, 0.01);
+        assert_eq!(
+            progress.elapsed,
+            Duration::minutes(4) + Duration::seconds(48)
+        );
+        assert_eq!(
+            progress.remaining,
+            Duration::hours(7) + Duration::minutes(55) + Duration::seconds(11),
+        );
+
+        let progress = Progress::new(timespan, from + Duration::minutes(24));
+        assert_eq!(progress.ratio, 0.05);
+        assert_eq!(progress.elapsed, Duration::minutes(24));
+        assert_eq!(
+            progress.remaining,
+            Duration::hours(7) + Duration::minutes(35) + Duration::seconds(59),
+        );
+
+        // current_time between from and to
+        let progress = Progress::new(timespan, from + Duration::hours(4));
+        assert_eq!(progress.ratio, 0.5);
+        assert_eq!(progress.elapsed, Duration::hours(4));
+        assert_eq!(
+            progress.remaining,
+            Duration::hours(3) + Duration::minutes(59) + Duration::seconds(59),
+        );
+
+        // current_time at to
+        let progress = Progress::new(timespan, to);
+        assert_eq!(progress.ratio, 1.0);
+        assert_eq!(progress.elapsed, timespan.duration);
+        assert_eq!(progress.remaining, Duration::zero());
+
+        // current_time after to
+        let progress = Progress::new(timespan, to + Duration::hours(1));
+        assert_eq!(progress.ratio, 1.0);
+        assert_eq!(progress.elapsed, timespan.duration);
+        assert_eq!(progress.remaining, Duration::zero());
     }
 }

--- a/src/renderer/default_renderer.rs
+++ b/src/renderer/default_renderer.rs
@@ -99,13 +99,6 @@ mod tests {
 
     use super::*;
 
-    // #[test]
-    // fn test_build_title() {
-    //     let title = "Just Do It!";
-    //     let expected = "Just Do It!";
-    //     let result = DefaultRenderer::build_title(title);
-    //     assert_eq!(result, expected);
-    // }
     #[test]
     fn test_build_bar() {
         let test_cases = vec![

--- a/src/renderer/synthwave_renderer.rs
+++ b/src/renderer/synthwave_renderer.rs
@@ -188,7 +188,7 @@ impl SynthwaveRenderer {
             "{:.0}% | {} elapsed | {} remaining",
             self.progress.ratio * 100.0,
             self.progress.format_elapsed(),
-            self.progress.timespan.format_duration()
+            self.progress.format_remaining()
         );
         let rigtht_space = width
             .saturating_sub(VERTICAL_BORDER.len_utf16())

--- a/src/timespan.rs
+++ b/src/timespan.rs
@@ -12,7 +12,7 @@ pub struct Timespan {
 impl Timespan {
     #[allow(clippy::missing_errors_doc)]
     pub fn new(from: NaiveDateTime, to: NaiveDateTime) -> Result<Self> {
-        if from > to {
+        if from >= to {
             Err(format_err!(DoItError::FromAfterTo { from, to }))
         } else {
             let duration = to - from;
@@ -109,34 +109,205 @@ impl Timespan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::DateTime;
 
     #[test]
     fn test_new_if_result_ok() {
-        let from = DateTime::from_timestamp(1_000_000_000, 0)
-            .unwrap()
-            .naive_utc();
-        let to = DateTime::from_timestamp(1_000_000_100, 0)
-            .unwrap()
-            .naive_utc();
-        assert!(Timespan::new(from, to).is_ok());
-        let from = DateTime::from_timestamp(1_000_000_100, 0)
-            .unwrap()
-            .naive_utc();
-        let to = DateTime::from_timestamp(1_000_000_100, 0)
-            .unwrap()
-            .naive_utc();
-        assert!(Timespan::new(from, to).is_ok());
+        let test_cases = [
+            ("2025-09-01 00:00:00", "2025-09-01 00:00:01"),
+            ("2025-09-01 00:00:00", "2025-09-01 00:01:00"),
+            ("2025-09-01 00:00:00", "2025-09-01 01:00:00"),
+            ("2025-09-01 00:00:00", "2025-09-02 00:00:00"),
+            ("2025-09-01 00:00:00", "2025-10-01 00:00:00"),
+            ("2025-09-01 00:00:00", "2026-09-01 00:00:00"),
+        ];
+        for (from_str, to_str) in test_cases {
+            let from = NaiveDateTime::parse_from_str(from_str, "%Y-%m-%d %H:%M:%S").unwrap();
+            let to = NaiveDateTime::parse_from_str(to_str, "%Y-%m-%d %H:%M:%S").unwrap();
+            assert!(
+                Timespan::new(from, to).is_ok(),
+                "from: {from_str}, to: {to_str}"
+            );
+        }
     }
 
     #[test]
     fn test_new_if_result_err() {
-        let from = DateTime::from_timestamp(1_000_000_100, 0)
-            .unwrap()
-            .naive_utc();
-        let to = DateTime::from_timestamp(1_000_000_000, 0)
-            .unwrap()
-            .naive_utc();
-        assert!(Timespan::new(from, to).is_err());
+        let test_cases = [
+            ("2025-09-01 00:00:00", "2025-09-01 00:00:00"),
+            ("2025-09-01 00:00:01", "2025-09-01 00:00:00"),
+            ("2025-09-01 00:01:00", "2025-09-01 00:00:00"),
+            ("2025-09-01 01:00:00", "2025-09-01 00:00:00"),
+            ("2025-09-02 00:00:00", "2025-09-01 00:00:00"),
+            ("2025-10-01 00:00:00", "2025-10-01 00:00:00"),
+            ("2026-09-01 00:00:00", "2026-09-01 00:00:00"),
+        ];
+        for (from_str, to_str) in test_cases {
+            let from = NaiveDateTime::parse_from_str(from_str, "%Y-%m-%d %H:%M:%S").unwrap();
+            let to = NaiveDateTime::parse_from_str(to_str, "%Y-%m-%d %H:%M:%S").unwrap();
+            assert!(
+                Timespan::new(from, to).is_err(),
+                "from: {from_str}, to: {to_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_has_expired() {
+        let test_cases = [
+            (
+                "2025-09-01 00:00",
+                "2025-09-01 12:00",
+                "2025-09-01 00:00",
+                false,
+            ),
+            (
+                "2025-09-01 00:00",
+                "2025-09-01 12:00",
+                "2025-09-01 06:00",
+                false,
+            ),
+            (
+                "2025-09-01 00:00",
+                "2025-09-01 12:00",
+                "2025-09-01 12:00",
+                true,
+            ),
+            (
+                "2025-09-01 00:00",
+                "2025-09-01 12:00",
+                "2025-08-31 00:00",
+                false,
+            ),
+            (
+                "2025-09-01 00:00",
+                "2025-09-01 12:00",
+                "2025-09-01 18:00",
+                true,
+            ),
+        ];
+        for (from_str, to_str, current_str, expected) in test_cases {
+            let from = NaiveDateTime::parse_from_str(from_str, "%Y-%m-%d %H:%M").unwrap();
+            let to = NaiveDateTime::parse_from_str(to_str, "%Y-%m-%d %H:%M").unwrap();
+            let current_time =
+                NaiveDateTime::parse_from_str(current_str, "%Y-%m-%d %H:%M").unwrap();
+            let timespan = Timespan::new(from, to).unwrap();
+            assert_eq!(timespan.has_expired(current_time), expected);
+        }
+    }
+
+    #[test]
+    fn test_progress() {
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00", "%Y-%m-%d %H:%M").unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59", "%Y-%m-%d %H:%M").unwrap();
+        let current_time =
+            NaiveDateTime::parse_from_str("2025-09-01 03:59", "%Y-%m-%d %H:%M").unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        let progress = timespan.progress(current_time);
+        assert_eq!(timespan, progress.timespan);
+        assert_eq!(current_time, progress.current_time);
+    }
+
+    #[test]
+    fn test_format_from() {
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00", "%Y-%m-%d %H:%M").unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59", "%Y-%m-%d %H:%M").unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        assert_eq!(timespan.format_from(), "00:00");
+    }
+
+    #[test]
+    fn test_format_to() {
+        let fmt = "%Y-%m-%d %H:%M";
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00", fmt).unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59", fmt).unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        assert_eq!(timespan.format_to(), "07:59");
+    }
+
+    #[test]
+    fn test_format_from_with_string() {
+        let fmt = "%Y-%m-%d %H:%M:%S";
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00:00", fmt).unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59:59", fmt).unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        assert_eq!(
+            timespan.format_from_with_string("%Y-%m-%d %H:%M:%S"),
+            "2025-09-01 00:00:00"
+        );
+        assert_eq!(timespan.format_from_with_string("%H:%M:%S"), "00:00:00");
+    }
+
+    #[test]
+    fn test_format_duration() {
+        let fmt = "%Y-%m-%d %H:%M:%S";
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00:00", fmt).unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59:59", fmt).unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        assert_eq!(timespan.format_duration(), "7 h 59 m");
+    }
+
+    #[test]
+    fn test_format_to_with_string() {
+        let fmt = "%Y-%m-%d %H:%M:%S";
+        let from = NaiveDateTime::parse_from_str("2025-09-01 00:00:00", fmt).unwrap();
+        let to = NaiveDateTime::parse_from_str("2025-09-01 07:59:59", fmt).unwrap();
+        let timespan = Timespan::new(from, to).unwrap();
+        assert_eq!(
+            timespan.format_to_with_string("%Y-%m-%d %H:%M:%S"),
+            "2025-09-01 07:59:59"
+        );
+        assert_eq!(timespan.format_to_with_string("%H:%M:%S"), "07:59:59");
+    }
+
+    #[test]
+    fn test_duration_strings() {
+        let test_cases = [
+            (Duration::minutes(45), "45 m"),
+            (Duration::hours(5), "5 h"),
+            (Duration::hours(5) + Duration::minutes(30), "5 h 30 m"),
+            (Duration::days(3), "3 d"),
+            (Duration::days(3) + Duration::hours(12), "3 d 12 h"),
+            (Duration::days(10), "10 d"),
+            (Duration::days(30), "30 d"),
+            (Duration::days(300), "300 d"),
+            (Duration::days(400), "1 y"),
+            (Duration::days(800), "2 y"),
+        ];
+        for (duration, expected) in test_cases {
+            assert_eq!(Timespan::format_duration_string(duration), expected);
+        }
+    }
+
+    #[test]
+    fn test_format_hours() {
+        let duration = Duration::hours(5);
+        assert_eq!(Timespan::format_hours(duration), "5 h");
+        let duration = Duration::hours(5) + Duration::minutes(30);
+        assert_eq!(Timespan::format_hours(duration), "5 h 30 m");
+    }
+
+    #[test]
+    fn test_format_days() {
+        let duration = Duration::days(3);
+        assert_eq!(Timespan::format_days(duration), "3 d");
+        let duration = Duration::days(3) + Duration::hours(12);
+        assert_eq!(Timespan::format_days(duration), "3 d 12 h");
+    }
+
+    #[test]
+    fn format_string() {
+        let test_cases = [
+            ("2025-09-01 00:00", "2025-09-01 12:00", "%H:%M"),
+            ("2025-09-01 00:00", "2025-09-01 23:59", "%H:%M"),
+            ("2025-09-01 00:00", "2025-09-02 00:00", "%m-%d %H:%M"),
+            ("2025-09-01 00:00", "2025-09-03 23:59", "%m-%d %H:%M"),
+            ("2025-09-01 00:00", "2025-09-30 23:59", "%Y-%m-%d"),
+        ];
+        for (from_str, to_str, expected) in test_cases {
+            let from = NaiveDateTime::parse_from_str(from_str, "%Y-%m-%d %H:%M").unwrap();
+            let to = NaiveDateTime::parse_from_str(to_str, "%Y-%m-%d %H:%M").unwrap();
+            let timespan = Timespan::new(from, to).unwrap();
+            assert_eq!(timespan.format_string(), expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the remaining time calculation logic within the Progress module.

## Changes Made

### Core Fixes
- **Fixed Progress::new()**: Corrected the logic for calculating remaining time based on current position within the timespan
- **Improved edge case handling**: Added proper handling for times before/after the timespan boundaries

### Code Quality Improvements
- **Comprehensive test coverage**: Added extensive test cases covering all edge scenarios for progress calculation
- **Timespan validation**: Enhanced timespan creation to properly handle equal from/to times
- **Renderer consistency**: Updated synthwave renderer to display remaining time instead of total duration

### Test Coverage
- Added detailed test cases for progress calculation at different timespan positions
- Verified correct behavior for edge cases (before start, after end, at boundaries)
- Enhanced timespan module tests with better coverage of duration formatting

## Testing

All existing tests pass, and new comprehensive test cases have been added to ensure the fix works correctly across all scenarios.

## Impact

This fix ensures that users see accurate remaining time calculations, improving the overall user experience of the progress tracking tool.