### PR TITLE
Hourglass renderer: new ASCII join style, centered, and progress-synced sand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"

--- a/README.md
+++ b/README.md
@@ -162,23 +162,26 @@ STATUS: > ALMOST THERE, SOLDIER! HOLD YOUR POSITION.
 ```
 Time is Flowing
 14:30 → 16:30   |   25%
-         ┏━━━━━━━━━┓
-         ┃░░░░░░░░░┃
-         ┃██░░░░░██┃
-         ┃█████████┃
-         ┃█████████┃
-          ┃███████┃
-           ┃█████┃
-            ┃███┃
-             ┃█┃
-             ┃┊┃
-            ┃░┊░┃
-           ┃░░┊░░┃
-          ┃░░░┊░░░┃
-         ┃░░░░┊░░░░┃
-         ┃░░████░░░┃
-         ┃█████████┃
-         ┗━━━━━━━━━┛
+           ┏━━━━━━━━━┓
+           ┃░░░░░░░░░┃
+           ┃██░░░░███┃
+           ┃█████████┃
+           ┃█████████┃
+           ┃█████████┃
+           ┃█████████┃
+           ┗━┓█████┏━┛
+             ┗━┓█┏━┛  
+               ┃┊┃
+             ┏━┛┊┗━┓  
+           ┏━┛░░┊░░┗━┓
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┃░░░░┊░░░░┃
+           ┗━━━━━━━━━┛
 elapsed: 30m   |   remaining: 1h 30m
 ```
 
@@ -235,8 +238,9 @@ cargo build --release  # Optimized build
 
 ### Hourglass Style Improvements
 - New header/body/footer layout (header: `from → to | %`, footer: `elapsed | remaining`).
-- Hourglass centered so its vertical axis aligns with the footer divider `|` dynamically.
+- Hourglass centered so its vertical axis aligns with the header/footer divider `|` dynamically.
 - Moving droplet animation (`┋`/`┊`) replacing simple blinking.
+- Fixed 60-cell sand capacity synced to progress; neck stays open at 100%.
 - All characters (borders, sand, droplet, symbols) refactored into constants for easy customization.
 
 ### v0.8.0

--- a/src/renderer/hourglass_renderer.rs
+++ b/src/renderer/hourglass_renderer.rs
@@ -25,8 +25,6 @@ const CH_FLOW_TRAIL: char = '┊';
 
 const CH_SPACE: char = ' ';
 
-// UI symbols (non-structural)
-const ICON_HOURGLASS: &str = "⏳";
 const SEP_ARROW: &str = "→";
 const INFO_DIVIDER: char = '|';
 
@@ -118,7 +116,8 @@ impl HourglassRenderer {
         [elapsed, remaining].join(format!("{space}{}{space}", INFO_DIVIDER).as_str())
     }
 
-    // Build full box (top border, interior 18 lines, bottom border)
+    // Build full box (top border, interior lines, bottom border)
+    // Interior lines = TOP_ROWS + 2 (top joins) + 1 (neck) + 2 (bottom joins) + BOTTOM_ROWS
     fn build_hourglass(&self) -> Vec<String> {
         let start = START_INSTANT.get_or_init(Instant::now);
         let elapsed = start.elapsed();
@@ -329,18 +328,6 @@ impl HourglassRenderer {
             CH_SPACE.to_string().repeat(indent),
             CH_BORDER_V,
             inner,
-            CH_BORDER_V
-        )
-    }
-
-    // Variant taking a prepared inner slice of chars
-    fn funnel_line_dyn(indent: usize, inner: &[char]) -> String {
-        let s: String = inner.iter().collect();
-        format!(
-            "{}{}{}{}",
-            CH_SPACE.to_string().repeat(indent),
-            CH_BORDER_V,
-            s,
             CH_BORDER_V
         )
     }

--- a/src/renderer/hourglass_renderer.rs
+++ b/src/renderer/hourglass_renderer.rs
@@ -30,9 +30,12 @@ const ICON_HOURGLASS: &str = "⏳";
 const SEP_ARROW: &str = "→";
 const INFO_DIVIDER: char = '|';
 
-// Top reservoir rows and bottom reservoir rows (matches the sample frames)
-const TOP_ROWS: usize = 5;
-const BOTTOM_ROWS: usize = 4;
+// Top/bottom reservoir row counts for the hourglass box interior
+// Ensure total movable sand capacity is 60 cells.
+// Top: 6 rows x 9 + joins (5+1) = 54 + 6 = 60
+// Bottom: joins (1+5) + 6 rows x 9 = 6 + 54 = 60 (neck is not counted)
+const TOP_ROWS: usize = 6;
+const BOTTOM_ROWS: usize = 6;
 
 pub struct HourglassRenderer {
     title: Option<String>,
@@ -57,9 +60,8 @@ impl StyledRenderer for HourglassRenderer {
         let header = self.build_information();
         row = Self::render_content(w, &header, row)?;
 
-        // Build footer first to compute alignment target (position of divider '|')
-        let footer = self.build_footer();
-        let divider_col = footer
+        // Align hourglass center to the '|' in the header line
+        let divider_col = header
             .chars()
             .enumerate()
             .find(|(_, c)| *c == INFO_DIVIDER)
@@ -79,7 +81,18 @@ impl StyledRenderer for HourglassRenderer {
             row += 1;
         }
 
-        row = Self::render_content(w, &footer, row)?;
+        // Footer: pad so its '|' aligns to the hourglass center
+        let footer = self.build_footer();
+        let footer_divider_col = footer
+            .chars()
+            .enumerate()
+            .find(|(_, c)| *c == INFO_DIVIDER)
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let footer_left_pad = (left_pad + base_center).saturating_sub(footer_divider_col);
+        let footer_pad = CH_SPACE.to_string().repeat(footer_left_pad);
+        let footer_padded = format!("{}{}", footer_pad, footer);
+        row = Self::render_content(w, &footer_padded, row)?;
         Ok(row)
     }
 }
@@ -111,27 +124,27 @@ impl HourglassRenderer {
         let elapsed = start.elapsed();
         let flow_active = !self.progress.is_complete();
 
-        // Total capacity per half (excluding borders): 61 cells
-        // bottom: 1 (neck) + 4 lower funnel (3,5,7,9) + 4 reservoir (9x4) = 61
-        // top:    4 upper funnel (1,3,5,7) + 5 reservoir (9x5) = 61
-        let total_cells = 61usize;
-        let filled = (self.progress.ratio.clamp(0.0, 1.0) * total_cells as f64).round() as usize;
+        // Compute total capacity (movable sand cells) = 60
+        // Done after defining `top_fun_widths` for clarity.
 
         // Prepare structures
         // Top reservoir (display order: top->bottom)
         let mut top_res: Vec<Vec<char>> =
             (0..TOP_ROWS).map(|_| vec![CH_SAND; INNER_WIDTH]).collect();
-        // Top funnel (display order: widths 7,5,3,1)
-        let top_fun_widths = [7usize, 5, 3, 1];
+        // Top funnel (new appearance): two join lines with inner widths 5 and 1
+        let top_fun_widths = [5usize, 1];
         let mut top_fun: Vec<Vec<char>> =
             top_fun_widths.iter().map(|&w| vec![CH_SAND; w]).collect();
+
+        // Compute total capacity (movable sand cells) from top geometry
+        let total_cells = TOP_ROWS * INNER_WIDTH + top_fun_widths.iter().sum::<usize>(); // 54 + 6 = 60
 
         // Bottom reservoir (display order: top->bottom)
         let mut bot_res: Vec<Vec<char>> = (0..BOTTOM_ROWS)
             .map(|_| vec![CH_EMPTY; INNER_WIDTH])
             .collect();
-        // Bottom funnel (display order: widths 3,5,7,9)
-        let bot_fun_widths = [3usize, 5, 7, 9];
+        // Bottom funnel (new appearance): two join lines with inner widths 1 and 5
+        let bot_fun_widths = [1usize, 5];
         let mut bot_fun: Vec<Vec<char>> =
             bot_fun_widths.iter().map(|&w| vec![CH_EMPTY; w]).collect();
         // Neck cell
@@ -160,22 +173,23 @@ impl HourglassRenderer {
             idx
         };
 
-        // Build bottom fill order (reservoir bottom->top, then funnel bottom->top, then neck)
-        let mut bottom_coords: Vec<(u8, usize, usize)> = Vec::with_capacity(total_cells);
+        // Build bottom fill order (reservoir bottom->top, then funnel bottom->top)
+        // Note: neck is excluded from capacity so total is exactly 60.
+        let mut bottom_coords: Vec<(u8, usize, usize)> = Vec::new();
         // Reservoir rows: bottom-most first
         for r in (0..BOTTOM_ROWS).rev() {
             for c in center_order(INNER_WIDTH) {
                 bottom_coords.push((0, r, c)); // 0 = bot_res
             }
         }
-        // Funnel rows: bottom-most (width 9) to top-most (width 3)
+        // Funnel rows: bottom-most first (width 5), then (width 1)
         for (i, &w) in bot_fun_widths.iter().enumerate().rev() {
             for c in center_order(w) {
                 bottom_coords.push((1, i, c)); // 1 = bot_fun
             }
         }
-        // Neck
-        bottom_coords.push((2, 0, 0)); // 2 = neck
+        // total_cells is fixed from top geometry (60)
+        let filled = (self.progress.ratio.clamp(0.0, 1.0) * total_cells as f64).round() as usize;
 
         // Apply bottom filled cells according to progress
         for (k, &(section, i, j)) in bottom_coords.iter().enumerate() {
@@ -185,8 +199,13 @@ impl HourglassRenderer {
             match section {
                 0 => bot_res[i][j] = CH_SAND,
                 1 => bot_fun[i][j] = CH_SAND,
-                _ => neck = CH_SAND,
+                _ => {}
             }
+        }
+
+        // At 100% completion, keep the neck visually open (empty)
+        if self.progress.is_complete() {
+            neck = CH_EMPTY;
         }
 
         // Build top empty order (reservoir top->down first, then funnel top side)
@@ -197,7 +216,7 @@ impl HourglassRenderer {
                 top_coords.push((4, r, c)); // 4 = top_res
             }
         }
-        // Funnel rows: top side first => index 0 (width7), 1 (width5), 2 (width3), 3 (width1)
+        // Funnel rows: top side first in new appearance => widths 5, then 1
         for i in 0..top_fun_widths.len() {
             let w = top_fun_widths[i];
             for c in center_order(w) {
@@ -278,16 +297,15 @@ impl HourglassRenderer {
         for r in 0..TOP_ROWS {
             lines.push(Self::boxed(top_res[r].iter().collect()));
         }
-        // Top funnel (display order widths 7,5,3,1 with indents 1..4)
+        // Top funnel join lines (widths 5, then 1)
         for (i, row) in top_fun.iter().enumerate() {
-            lines.push(Self::funnel_line_dyn(1 + i, row));
+            lines.push(Self::join_line_top(row, i));
         }
         // Neck
         lines.push(Self::funnel_line(4, neck_char, 1));
-        // Lower funnel (display order widths 3,5,7,9 with indents 3..0)
+        // Lower funnel join lines (widths 1, then 5)
         for (i, row) in bot_fun.iter().enumerate() {
-            let indent = 3usize.saturating_sub(i);
-            lines.push(Self::funnel_line_dyn(indent, row));
+            lines.push(Self::join_line_bottom(row, i));
         }
         // Lower reservoir (display order)
         for r in 0..BOTTOM_ROWS {
@@ -324,6 +342,40 @@ impl HourglassRenderer {
             CH_BORDER_V,
             s,
             CH_BORDER_V
+        )
+    }
+
+    // Join line for the top funnel section using corner connectors
+    // i = 0 => width 5 with indent 0; i = 1 => width 1 with indent 2
+    fn join_line_top(inner: &[char], i: usize) -> String {
+        let w = inner.len();
+        let total = INNER_WIDTH + 2; // full interior width of the hourglass area
+        let left_indent = if i == 0 { 0 } else { 2 };
+        let used = left_indent + 3 + w + 3; // left + "┗━┓" + inner + "┏━┛"
+        let right_pad = total.saturating_sub(used);
+        let inner_s: String = inner.iter().collect();
+        format!(
+            "{}┗━┓{}┏━┛{}",
+            CH_SPACE.to_string().repeat(left_indent),
+            inner_s,
+            CH_SPACE.to_string().repeat(right_pad)
+        )
+    }
+
+    // Join line for the bottom funnel section using corner connectors
+    // i = 0 => width 1 with indent 2; i = 1 => width 5 with indent 0
+    fn join_line_bottom(inner: &[char], i: usize) -> String {
+        let w = inner.len();
+        let total = INNER_WIDTH + 2;
+        let left_indent = if i == 0 { 2 } else { 0 };
+        let used = left_indent + 3 + w + 3; // left + "┏━┛" + inner + "┗━┓"
+        let right_pad = total.saturating_sub(used);
+        let inner_s: String = inner.iter().collect();
+        format!(
+            "{}┏━┛{}┗━┓{}",
+            CH_SPACE.to_string().repeat(left_indent),
+            inner_s,
+            CH_SPACE.to_string().repeat(right_pad)
         )
     }
 


### PR DESCRIPTION
This PR updates the hourglass renderer appearance and behavior.
Key changes
- Align hourglass center with the header/footer divider  regardless of date format.
- Update funnels to the specified join style (┗━┓…┏━┛ / ┏━┛…┗━┓).
- Adjust geometry to a fixed 60-cell movable sand capacity (TOP_ROWS=6, BOTTOM_ROWS=6).
- Sync sand with progress: exactly round(r*60) cells move from top to bottom.
- Keep neck visually open (░) at 100% (no flow).
- Preserve animation and existing CLI behavior.
 
Screenshots/verification
- Verified alignment in header/footer and sand distribution across different header formats.

Let me know if you'd like different characters, speeds, or a compact variant.