### PR TITLE
Hourglass: align center to farther-right '|' and pad header/footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "tracing-subscriber",
+ "unicode-width",
 ]
 
 [[package]]
@@ -876,6 +877,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "2.0.16"
 regex = "1.11.1"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["fmt", "env-filter"] }
+unicode-width = "0.1.14"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"

--- a/docs/screenshots/hourglass/date-range.svg
+++ b/docs/screenshots/hourglass/date-range.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="520" viewBox="0 0 900 520">
+  <rect width="100%" height="100%" fill="#111"/>
+  <g font-family="DejaVu Sans Mono, Menlo, Consolas, monospace" font-size="16" fill="#eee">
+    <text x="16" y="32">
+      <tspan x="16" dy="0">2025-01-01 → 2025-12-31   |   66%</tspan>
+      <tspan x="16" dy="22">                     ┏━━━━━━━━━┓</tspan>
+      <tspan x="16" dy="22">                     ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃██░░░░███┃</tspan>
+      <tspan x="16" dy="22">                     ┃█████████┃</tspan>
+      <tspan x="16" dy="22">                     ┗━┓█████┏━┛</tspan>
+      <tspan x="16" dy="22">                       ┗━┓█┏━┛  </tspan>
+      <tspan x="16" dy="22">                         ┃┊┃</tspan>
+      <tspan x="16" dy="22">                       ┏━┛┊┗━┓  </tspan>
+      <tspan x="16" dy="22">                     ┏━┛░░┊░░┗━┓</tspan>
+      <tspan x="16" dy="22">                     ┃░░░░┊░░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃░░████░░░┃</tspan>
+      <tspan x="16" dy="22">                     ┃█████████┃</tspan>
+      <tspan x="16" dy="22">                     ┃█████████┃</tspan>
+      <tspan x="16" dy="22">                     ┃█████████┃</tspan>
+      <tspan x="16" dy="22">                     ┃█████████┃</tspan>
+      <tspan x="16" dy="22">                     ┗━━━━━━━━━┛</tspan>
+      <tspan x="16" dy="22">          elapsed: 241d   |   remaining: 123d</tspan>
+    </text>
+  </g>
+  <rect x="8" y="8" width="884" height="504" fill="none" stroke="#111"/>
+ </svg>

--- a/docs/screenshots/hourglass/time-range.svg
+++ b/docs/screenshots/hourglass/time-range.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="520" viewBox="0 0 900 520">
+  <rect width="100%" height="100%" fill="#111"/>
+  <g font-family="DejaVu Sans Mono, Menlo, Consolas, monospace" font-size="16" fill="#eee">
+    <text x="16" y="32">
+      <tspan x="16" dy="0">  10:00 → 19:00   |   70%</tspan>
+      <tspan x="16" dy="22">             ┏━━━━━━━━━┓</tspan>
+      <tspan x="16" dy="22">             ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">             ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">             ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">             ┃░░░░░░░░░┃</tspan>
+      <tspan x="16" dy="22">             ┃█░░░░░░██┃</tspan>
+      <tspan x="16" dy="22">             ┃█████████┃</tspan>
+      <tspan x="16" dy="22">             ┗━┓█████┏━┛</tspan>
+      <tspan x="16" dy="22">               ┗━┓█┏━┛</tspan>
+      <tspan x="16" dy="22">                 ┃┊┃</tspan>
+      <tspan x="16" dy="22">               ┏━┛┊┗━┓</tspan>
+      <tspan x="16" dy="22">             ┏━┛░░┊░░┗━┓</tspan>
+      <tspan x="16" dy="22">             ┃░░░░┊░░░░┃</tspan>
+      <tspan x="16" dy="22">             ┃░██████░░┃</tspan>
+      <tspan x="16" dy="22">             ┃█████████┃</tspan>
+      <tspan x="16" dy="22">             ┃█████████┃</tspan>
+      <tspan x="16" dy="22">             ┃█████████┃</tspan>
+      <tspan x="16" dy="22">             ┃█████████┃</tspan>
+      <tspan x="16" dy="22">             ┗━━━━━━━━━┛</tspan>
+      <tspan x="16" dy="22">elapsed: 6h 22m   |   remaining: 2h 37m</tspan>
+    </text>
+  </g>
+  <rect x="8" y="8" width="884" height="504" fill="none" stroke="#111"/>
+ </svg>

--- a/src/renderer/hourglass_renderer.rs
+++ b/src/renderer/hourglass_renderer.rs
@@ -5,6 +5,7 @@ use crossterm::{cursor::MoveTo, queue};
 use std::io::Write;
 use std::sync::OnceLock;
 use std::time::Instant;
+use unicode_width::UnicodeWidthChar;
 
 // Fixed inner width of the hourglass content (between the side borders)
 const INNER_WIDTH: usize = 9;
@@ -56,17 +57,29 @@ impl StyledRenderer for HourglassRenderer {
         };
 
         let header = self.build_information();
-        row = Self::render_content(w, &header, row)?;
+        let footer = self.build_footer();
 
-        // Align hourglass center to the '|' in the header line
-        let divider_col = header
-            .chars()
-            .enumerate()
-            .find(|(_, c)| *c == INFO_DIVIDER)
-            .map(|(i, _)| i)
-            .unwrap_or(0);
+        // Determine visual widths and divider columns using Unicode display width
+        let (header_width, header_divider) = Self::visual_width_and_divider(&header);
+        let (footer_width, footer_divider) = Self::visual_width_and_divider(&footer);
+        let global_center = if header_width >= footer_width {
+            header_divider
+        } else {
+            footer_divider
+        };
+
+        // Compute paddings so each '|' aligns to global_center
+        let header_left_pad = global_center.saturating_sub(header_divider);
+        let footer_left_pad = global_center.saturating_sub(footer_divider);
+        let header_padded = format!("{}{}", CH_SPACE.to_string().repeat(header_left_pad), header);
+        let footer_padded = format!("{}{}", CH_SPACE.to_string().repeat(footer_left_pad), footer);
+
+        // Render padded header
+        row = Self::render_content(w, &header_padded, row)?;
+
+        // Align hourglass center to global_center
         let base_center = 1 + (INNER_WIDTH / 2); // center index of full-width hourglass line
-        let left_pad = divider_col.saturating_sub(base_center);
+        let left_pad = global_center.saturating_sub(base_center);
         let pad = CH_SPACE.to_string().repeat(left_pad);
 
         // Render the hourglass box
@@ -79,23 +92,25 @@ impl StyledRenderer for HourglassRenderer {
             row += 1;
         }
 
-        // Footer: pad so its '|' aligns to the hourglass center
-        let footer = self.build_footer();
-        let footer_divider_col = footer
-            .chars()
-            .enumerate()
-            .find(|(_, c)| *c == INFO_DIVIDER)
-            .map(|(i, _)| i)
-            .unwrap_or(0);
-        let footer_left_pad = (left_pad + base_center).saturating_sub(footer_divider_col);
-        let footer_pad = CH_SPACE.to_string().repeat(footer_left_pad);
-        let footer_padded = format!("{}{}", footer_pad, footer);
+        // Render padded footer
         row = Self::render_content(w, &footer_padded, row)?;
         Ok(row)
     }
 }
 
 impl HourglassRenderer {
+    // Calculate visual display width and the visual column of the divider '|'
+    fn visual_width_and_divider(s: &str) -> (usize, usize) {
+        let mut width = 0usize;
+        let mut divider_col = 0usize;
+        for ch in s.chars() {
+            if ch == INFO_DIVIDER {
+                divider_col = width;
+            }
+            width += UnicodeWidthChar::width(ch).unwrap_or(1);
+        }
+        (width, divider_col)
+    }
     fn build_title(&self) -> Option<String> {
         self.title.clone()
     }


### PR DESCRIPTION

---

Before/After

Date range (top is longer):

Before:
```text
2025-01-01 → 2025-12-31   |   66%
           ┏━━━━━━━━━┓
           …
          elapsed: 241d   |   remaining: 123d
```
After:
```text
2025-01-01 → 2025-12-31   |   66%
                     ┏━━━━━━━━━┓
                     …
          elapsed: 241d   |   remaining: 123d
```

Time range (bottom is longer):

Before:
```text
10:00 → 19:00   |   70%
           ┏━━━━━━━━━┓
           …
elapsed: 6h 22m   |   remaining: 2h 37m
```
After:
```text
  10:00 → 19:00   |   70%
             ┏━━━━━━━━━┓
             …
elapsed: 6h 22m   |   remaining: 2h 37m
```
### Screenshots

Date range (top is longer):

![Date range](docs/screenshots/hourglass/date-range.svg)

Time range (bottom is longer):

![Time range](docs/screenshots/hourglass/time-range.svg)