### PR TITLE
Fix interval option range validation to allow 60 seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "doit"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doit"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 authors = ["Shuhei Matsuoka <matsuokashuheiii@gmail.com>"]
 description = "A CLI progress monitor (doit) for time-based visualization"


### PR DESCRIPTION
## Summary

Fixes a bug in the `--interval` option validation where users couldn't set the interval to exactly 60 seconds.

## Changes

- **Bug Fix**: Changed interval validation from `1..60` (exclusive) to `1..=60` (inclusive) to allow exactly 60 seconds
- **Testing**: Added comprehensive test cases for interval validation:
  - Success cases: 1, 10, and 60 seconds
  - Failure cases: -1, 0, and 61 seconds  
- **Version**: Bumped version to 0.10.2

## Problem

The previous validation used `1..60` which excludes 60, meaning users who tried to set `--interval 60` would get a validation error despite 60 being a reasonable interval value.

## Solution

Changed to `1..=60` to include 60 in the valid range, allowing users to set the maximum intended interval of 60 seconds.

## Testing

Added unit tests to verify both valid and invalid interval values are handled correctly.